### PR TITLE
Make gem easier to config with defaults

### DIFF
--- a/lib/postnord.rb
+++ b/lib/postnord.rb
@@ -4,6 +4,7 @@ require 'net/https'
 require 'json'
 require 'openssl'
 
+require 'postnord/config'
 require 'postnord/client'
 require 'postnord/response'
 require 'postnord/base'

--- a/lib/postnord/client.rb
+++ b/lib/postnord/client.rb
@@ -1,24 +1,20 @@
 module Postnord
   class Client
-    POSTNORD_API_KEY = ''
-    POSTNORD_API_VERSION = 'v1'
-    POSTNORD_API_ENDPOINT = 'https://api2.postnord.com/rest'
-    POSTNORD_LOCALE = 'en'
-    POSTNORD_RETURN_TYPE = 'json'
 
     def initialize(options={})
-      @api_version = options[:api_version] || POSTNORD_API_VERSION
-      @api_key = options[:api_key] || POSTNORD_API_KEY
-      @locale = options[:locale] || POSTNORD_LOCALE || 'en'
-      @returntype = options[:returntype] || POSTNORD_RETURN_TYPE || 'json'
+      @api_version  = options[:api_version]  || Config.api_version
+      @api_key      = options[:api_key]      || Config.api_key
+      @api_endpoint = options[:api_endpoint] || Config.api_endpoint
+      @locale       = options[:locale]       || Config.locale
+      @return_type  = options[:return_type]  || Config.return_type
     end
 
     def do_request(service, endpoint, params={})
       uri = build_uri(service, endpoint)
 
       params.merge!(
-        apikey: POSTNORD_API_KEY,
-        locale: POSTNORD_LOCALE,
+        apikey: @api_key,
+        locale: @locale,
       )
 
       uri.query = URI.encode_www_form(params)
@@ -35,11 +31,11 @@ module Postnord
 
     def build_uri(service, endpoint)
       URI(
-        POSTNORD_API_ENDPOINT +
+        @api_endpoint +
         '/' + service +
-        '/' + POSTNORD_API_VERSION +
+        '/' + @api_version +
         '/' + endpoint +
-        '.' + POSTNORD_RETURN_TYPE
+        '.' + @return_type
       )
     end
   end

--- a/lib/postnord/config.rb
+++ b/lib/postnord/config.rb
@@ -1,0 +1,25 @@
+module Postnord
+  class Config
+
+    def self.api_key
+      (defined? POSTNORD_API_KEY) ? POSTNORD_API_KEY : ''
+    end
+
+    def self.api_version
+      (defined? POSTNORD_API_VERSION) ? POSTNORD_API_VERSION : 'v1'
+    end
+
+    def self.api_endpoint
+      (defined? POSTNORD_API_ENDPOINT) ? POSTNORD_API_ENDPOINT : 'https://api2.postnord.com/rest'
+    end
+
+    def self.locale
+      (defined? POSTNORD_LOCALE) ? POSTNORD_LOCALE : 'en'
+    end
+
+    def self.return_type
+      (defined? POSTNORD_RETURN_TYPE) ? POSTNORD_RETURN_TYPE : 'json'
+    end
+
+  end
+end

--- a/lib/postnord/version.rb
+++ b/lib/postnord/version.rb
@@ -1,3 +1,3 @@
 module Postnord
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/postnord/config_spec.rb
+++ b/spec/postnord/config_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe Postnord::Config do
+
+  context 'without global config variables' do
+
+    context 'api_key' do
+      it { expect(described_class.api_key).to eq('') }
+    end
+
+    context 'api_version' do
+      it { expect(described_class.api_version).to eq('v1') }
+    end
+
+    context 'api_endpoint' do
+      it { expect(described_class.api_endpoint).to eq('https://api2.postnord.com/rest') }
+    end
+
+    context 'locale' do
+      it { expect(described_class.locale).to eq('en') }
+    end
+
+    context 'return_type' do
+      it { expect(described_class.return_type).to eq('json') }
+    end
+  end
+
+  context 'with global config variables' do
+    before :all do
+      POSTNORD_API_KEY = '12345'
+      POSTNORD_API_VERSION = 'v2'
+      POSTNORD_API_ENDPOINT = 'http://newurl.com/'
+      POSTNORD_LOCALE = 'sv'
+      POSTNORD_RETURN_TYPE = 'xml'
+    end
+
+    context 'api_key' do
+      it { expect(described_class.api_key).to eq(POSTNORD_API_KEY) }
+    end
+
+    context 'api_version' do
+      it { expect(described_class.api_version).to eq(POSTNORD_API_VERSION) }
+    end
+
+    context 'api_endpoint' do
+      it { expect(described_class.api_endpoint).to eq(POSTNORD_API_ENDPOINT) }
+    end
+
+    context 'locale' do
+      it { expect(described_class.locale).to eq(POSTNORD_LOCALE) }
+    end
+
+    context 'return_type' do
+      it { expect(described_class.return_type).to eq(POSTNORD_RETURN_TYPE) }
+    end
+  end
+end


### PR DESCRIPTION
### Changes
- Adds a config module to the gem, making it easier to choose between app config and defaults.
- Makes sure that the client uses your configuration and not the defaults if given.
