### PR TITLE
[#27483] Update transit times api

### DIFF
--- a/lib/postnord/base.rb
+++ b/lib/postnord/base.rb
@@ -9,7 +9,7 @@ module Postnord
     end
 
     def self.client
-      @client ||= Client.new
+      @client ||= Client.new(options)
     end
 
     private
@@ -23,15 +23,19 @@ module Postnord
     end
 
     def self.action
-      self.name.split('::').last.tap { |e| e[0] = e[0].downcase }
+      self.name.split("::").last.tap { |e| e[0] = e[0].downcase }
     end
 
     def self.mandatory_params
-      fail NotImplementedError, 'mandatory_params'
+      fail NotImplementedError, "mandatory_params"
     end
 
     def self.endpoint
-      fail NotImplementedError, 'endpoint'
+      fail NotImplementedError, "endpoint"
+    end
+
+    def self.options
+      {}
     end
   end
 end

--- a/lib/postnord/client.rb
+++ b/lib/postnord/client.rb
@@ -6,7 +6,11 @@ module Postnord
       @api_key      = options[:api_key]      || Config.api_key
       @api_endpoint = options[:api_endpoint] || Config.api_endpoint
       @locale       = options[:locale]       || Config.locale
-      @return_type  = options[:return_type]  || Config.return_type
+      @return_type  = if options.has_key?(:return_type)
+        options[:return_type]
+      else
+        Config.return_type
+      end
     end
 
     def do_request(service, endpoint, params={})
@@ -27,13 +31,13 @@ module Postnord
     private
 
     def build_uri(service, endpoint)
-      URI(
-        @api_endpoint +
-        '/' + service +
-        '/' + @api_version +
-        '/' + endpoint +
-        '.' + @return_type
-      )
+      url = @api_endpoint +
+      "/" + service +
+      "/" + @api_version +
+      "/" + endpoint
+      url += "." + @return_type if @return_type
+
+      URI(url)
     end
   end
 end

--- a/lib/postnord/transport.rb
+++ b/lib/postnord/transport.rb
@@ -12,6 +12,27 @@ module Postnord
     end
   end
 
+  class AddressToAddress < Transport
+    def self.mandatory_params
+      [
+        "startTime",
+        "serviceGroup",
+        "originPostCode",
+        "originCountryCode",
+        "destinationPostCode",
+        "destinationCountryCode",
+      ]
+    end
+
+    def self.action
+      self.name.split('::').last.downcase
+    end
+
+    def self.options
+      { return_type: nil }
+    end
+  end
+
   class GetTransitTimeInformation < Transport
     def self.mandatory_params
       [

--- a/lib/postnord/version.rb
+++ b/lib/postnord/version.rb
@@ -1,3 +1,3 @@
 module Postnord
-  VERSION = "0.3.0"
+  VERSION = "1.0.0"
 end

--- a/postnord.gemspec
+++ b/postnord.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'postnord/version'
+require "postnord/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "postnord"
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Stefan Åhman"]
   spec.email         = ["stefan.ahman@apoex.se"]
 
-  spec.summary       = %q{A gem for Postnord's API}
-  spec.homepage      = 'https://github.com/apoex/postnord'
+  spec.summary       = %q{A gem for Postnord"s API}
+  spec.homepage      = "https://github.com/apoex/postnord"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
@@ -18,10 +18,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday'
+  spec.add_dependency "faraday"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "pry-byebug"
+  spec.add_development_dependency "pry-byebyebug"
   spec.add_development_dependency "simplecov", "~> 0.17.1"
 end

--- a/spec/postnord/client_spec.rb
+++ b/spec/postnord/client_spec.rb
@@ -1,16 +1,16 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Postnord::Client do
-  subject { Postnord::Client.new(api_version: 'v1', api_key: 'test', api_endpoint: 'test_endpoint', locale: 'sv', return_type: 'json') }
+  subject { Postnord::Client.new(api_version: "v1", api_key: "test", api_endpoint: "http://test_endpoint", locale: "sv", return_type: "json") }
 
   before do
     stub_request(:get, /test_endpoint/).to_return(status: 200, body: '{ "test": "data" }', headers: {})
   end
 
-  it 'does the request' do
-    res = subject.do_request('service', 'endpoint')
+  it "does the request" do
+    res = subject.do_request("service", "endpoint")
 
     expect(res.code).to eq(200)
-    expect(res.data).to eq({ 'test' => 'data' })
+    expect(res.data).to eq({ "test" => "data" })
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,10 @@
-require 'bundler/setup'
-require 'webmock/rspec'
+require "bundler/setup"
+require "webmock/rspec"
 
-require 'simplecov'
+require "simplecov"
 
 SimpleCov.start
 
-require 'postnord'
+require "postnord"
+require "pry-byebyebug"
+require "pry-byebug"


### PR DESCRIPTION
Old API is deprecated. This will update the transit times part of the gem.

Old: https://developer.postnord.com/apis/details?systemName=shipment-v1-trackandtrace

New: https://developer.postnord.com/apis/details?systemName=transport-v1-transittime-calculation